### PR TITLE
init: Run restorecon_recursive asynchronously

### DIFF
--- a/init/property_service.h
+++ b/init/property_service.h
@@ -27,6 +27,8 @@ struct property_audit_data {
     const char* name;
 };
 
+extern bool property_child_reap(pid_t pid);
+
 extern void property_init(void);
 extern void property_load_boot_defaults(void);
 extern void load_persist_props(void);

--- a/init/service.cpp
+++ b/init/service.cpp
@@ -780,6 +780,8 @@ bool ServiceManager::ReapOneProcess() {
     } else if (pid == -1) {
         ERROR("waitpid failed: %s\n", strerror(errno));
         return false;
+    } else if (property_child_reap(pid)) {
+        return true;
     }
 
     Service* svc = FindServiceByPid(pid);


### PR DESCRIPTION
restorecon_recursive may take a long time if there are a lot of files on
the volume.  This can trigger a watchdog timeout in any process that
tries to set a property while it is running.  Fix this by running
restorecon_recursive in its own process.

See https://jira.lineageos.org/browse/BUGBASH-555

Change-Id: I2ce26ff2b5bfc9a133ea42f4dbac50a3ac289c04